### PR TITLE
copy: show snackbar message

### DIFF
--- a/src/actions/snackbar.js
+++ b/src/actions/snackbar.js
@@ -7,7 +7,16 @@ export const hideSnackbar = (data) => {
     };
 };
 
-export const showSnackbar = (data) => {
+export const showSnackbar = (data) => (dispatch) => {
+    // using setTimeout(dispatch, 0) to queue SNACKBAR_SHOW
+    // after SNACKBAR_HIDE emitted by the click-away listener
+    // of any existing snackbar
+    setTimeout(() => {
+        dispatch(_showSnackbar(data));
+    }, 0);
+};
+
+const _showSnackbar = (data) => {
     return {
         type: SNACKBAR_SHOW,
         data,

--- a/src/components/Copy/index.js
+++ b/src/components/Copy/index.js
@@ -1,12 +1,25 @@
 import './index.css';
 import * as PropTypes from 'prop-types';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
+import { showSnackbar } from '../../actions/snackbar';
+import { useDispatch } from 'react-redux';
 import Icon from '../Icon';
 import React from 'react';
 
 const Copy = ({ text }) => {
+    const dispatch = useDispatch();
+
+    const showSnack = () => {
+        dispatch(showSnackbar({
+            message: `Copied to clipboard: ${text}`,
+        }));
+    };
+
     return (
-        <CopyToClipboard text={text}>
+        <CopyToClipboard
+            text={text}
+            onCopy={showSnack}
+        >
             <div className="copy-section">
                 <div className="flex-center">
                     <Icon

--- a/src/components/Copy/index.js
+++ b/src/components/Copy/index.js
@@ -6,16 +6,16 @@ import React from 'react';
 
 const Copy = ({ text }) => {
     return (
-        <div className="copy-section">
-            <CopyToClipboard text={text}>
+        <CopyToClipboard text={text}>
+            <div className="copy-section">
                 <div className="flex-center">
                     <Icon
                         className="icon"
                         icon="copy"
                     />
                 </div>
-            </CopyToClipboard>
-        </div>
+            </div>
+        </CopyToClipboard>
     );
 };
 


### PR DESCRIPTION


https://user-images.githubusercontent.com/44864521/114172828-d502d500-9953-11eb-98c4-611542f81406.mov


reason for last commit: the click on row 3 ^^^ would hide the snackbar entirely (bug) instead of hiding the old one and showing a new one.